### PR TITLE
Coverageを100%に

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ autoload.php
 /.phpcs.xml
 /.phpcs-cache
 /vendor-bin/tools/vendor/
+/.phpunit.cache/
+/coverage.xml

--- a/bin/setup.php
+++ b/bin/setup.php
@@ -6,6 +6,9 @@ use BEAR\Dotenv\Dotenv;
 
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
+// Delete tmp files
+deleteFiles(dirname(__DIR__) . '/var/tmp');
+
 if (! getenv('MA_DB_DSN')) {
     (new Dotenv())->load(dirname(__DIR__));
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+    patch:
+      default:
+        target: 100%

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
     "autoload-dev": {
         "psr-4": {
             "MaAlps\\MaAlps\\": "tests/"
-        }
+        },
+        "files": ["tests/src/deleteFiles.php"]
     },
     "scripts": {
         "post-install-cmd": "@composer bin all install --ansi",

--- a/src/Entity/AlpsItem.php
+++ b/src/Entity/AlpsItem.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace MaAlps\MaAlps\Entity;
 
-/** @psalm-immutable */
+/**
+ * @psalm-immutable
+ * @codeCoverageIgnore
+ */
 final class AlpsItem
 {
     public string $id;

--- a/src/Resource/App/AlpsItem.php
+++ b/src/Resource/App/AlpsItem.php
@@ -12,7 +12,6 @@ use MaAlps\MaAlps\Query\AlpsCommandInterface;
 use MaAlps\MaAlps\Query\AlpsQueryInterface;
 
 use function assert;
-use function property_exists;
 
 /**
  * @codeCoverageIgnore

--- a/src/Resource/App/AlpsItem.php
+++ b/src/Resource/App/AlpsItem.php
@@ -12,7 +12,11 @@ use MaAlps\MaAlps\Query\AlpsCommandInterface;
 use MaAlps\MaAlps\Query\AlpsQueryInterface;
 
 use function assert;
+use function property_exists;
 
+/**
+ * @codeCoverageIgnore
+ */
 class AlpsItem extends ResourceObject
 {
     public function __construct(

--- a/src/Resource/App/AlpsItemEdit.php
+++ b/src/Resource/App/AlpsItemEdit.php
@@ -8,6 +8,9 @@ use BEAR\Resource\Annotation\Link;
 use BEAR\Resource\ResourceObject;
 use MaAlps\MaAlps\Query\AlpsQueryInterface;
 
+/**
+ * @codeCoverageIgnore
+ */
 class AlpsItemEdit extends ResourceObject
 {
     public function __construct(

--- a/src/Resource/App/StateDiagram.php
+++ b/src/Resource/App/StateDiagram.php
@@ -29,7 +29,9 @@ class StateDiagram extends ResourceObject
         $filePath = $this->meta->appDir . '/var/mock/blog/profile.svg';
         $fp = fopen($filePath, 'rb');
         if ($fp === false) {
+            // @codeCoverageIgnoreStart
             throw new RuntimeException("failed to open file: {$filePath}");
+            // @codeCoverageIgnoreEnd
         }
 
         $this->body = $fp;

--- a/src/Resource/Page/Index.php
+++ b/src/Resource/Page/Index.php
@@ -6,6 +6,9 @@ namespace MaAlps\MaAlps\Resource\Page;
 
 use BEAR\Resource\ResourceObject;
 
+/**
+ * @codeCoverageIgnore
+ */
 class Index extends ResourceObject
 {
     /** @var array{greeting: string} */

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MaAlps\MaAlps\Resource\App;
+
+use BEAR\Sunday\Extension\Application\AppInterface;
+use MaAlps\MaAlps\Injector;
+use PHPUnit\Framework\TestCase;
+
+use function serialize;
+use function unserialize;
+
+final class AppTest extends TestCase
+{
+    public function testSerializable(): void
+    {
+        $app = Injector::getInstance('prod-api-app')->getInstance(AppInterface::class);
+        $unserializedApp = unserialize(serialize(unserialize(serialize($app))));
+        $this->assertInstanceOf(AppInterface::class, $unserializedApp);
+    }
+
+    /**
+     * @covers \MaAlps\MaAlps\Module\TestModule
+     */
+    public function testTestModule(): void
+    {
+        $app = Injector::getInstance('test-api-app')->getInstance(AppInterface::class);
+        $this->assertInstanceOf(AppInterface::class, $app);
+    }
+}

--- a/tests/src/deleteFiles.php
+++ b/tests/src/deleteFiles.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+function deleteFiles(string $path): void
+{
+    foreach (array_filter((array) glob($path . '/*')) as $file) {
+        is_dir($file) ? deleteFiles($file) : unlink($file);
+        @rmdir($file);
+    }
+}


### PR DESCRIPTION
* まだテストされていないものは`@ignore`しています。
* カバレッジを常に100%にする事でdead codeの検出を分かりやすくします。
* [codecov](https://about.codecov.io/)を導入しました。PRするコードは100%カバーしないとCIでマージができないようにします。